### PR TITLE
Configure github action environment for Python 3.6

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,10 +12,10 @@ jobs:
     
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.6
     - name: Setup Graphviz
       uses: ts-graphviz/setup-graphviz@v1
     - name: Install dependencies


### PR DESCRIPTION
Configures CI to use Python 3.6 to ensure backward-compatibility
Related to #46 