### PR TITLE
Move paml-check to optional requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ test_deps = [
 ]
 extras = {
     'test': test_deps,
+    'paml-check': 'paml-check@ https://github.com/SD2E/paml-check/tarball/development',
 }
 
 setup(name='paml',
@@ -36,7 +37,6 @@ setup(name='paml',
             'transcriptic',
             'requests_html',
             "container-ontology @ https://github.com/rpgoldman/container-ontology/tarball/main",
-            "paml-check @ https://github.com/SD2E/paml-check/tarball/development",
             "ipython",
             "pre-commit",
             "ipywidgets"


### PR DESCRIPTION
`pip install paml` fails on OS X because the z3 solver requires cmake, which is not included by default on OS X.  To avoid this, this PR moves `paml-check` to an optional dependency.  Resolves #81 

To install from pypi:
`pip install -e "paml[paml-check]"`

To install a local development version:
`pip install -e ".[paml-check]"`

To install from github:
`pip install -e "git+https://github.com/bioprotocols/paml.git@81-paml_check#egg=paml[paml-check]"`