### PR TITLE
Fix container submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "paml-check"]
 	path = paml-check
 	url = https://github.com/SD2E/paml-check/
+[submodule "container-ontology"]
+	path = container-ontology
+	url = https://github.com/Bioprotocols/container-ontology

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "paml-check"]
 	path = paml-check
 	url = https://github.com/SD2E/paml-check/
-[submodule "container-ontology"]
-	path = container-ontology
-	url = https://github.com/rpgoldman/container-ontology


### PR DESCRIPTION
The `container-ontology` submodule was previously taken from @rpgoldman 's private repo.  This PR replaces the submodule with the public fork of the `container-ontology`.